### PR TITLE
Make basePath configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "auto-commit-gpt",
   "displayName": "Auto Commit with GPT",
   "description": "Generate commit messages using ChatGPT",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "homepage": "https://github.com/sohanemon/AutoCommit#readme",
   "bugs": "https://github.com/sohanemon/AutoCommit/issues",
   "repository": {
@@ -56,6 +56,11 @@
           "type": "string",
           "default": "",
           "description": "Needed for generating AI commit messages"
+        },
+        "autocommit.openAI.apiUrl": {
+          "type": "string",
+          "default": "https://api.openai.com",
+          "description": "Required for generating AI commit messages. Should start with \"https://\""
         },
         "autocommit.appearance.delimeter": {
           "type": "string",

--- a/src/autocommit/index.ts
+++ b/src/autocommit/index.ts
@@ -10,7 +10,7 @@ import { assertGitRepo, getStagedDiff, stageAllChanges } from './utils/git';
 import { generateCommitMessage } from './utils/openai';
 import { runTaskWithTimeout } from './utils/timer';
 
-async function generateAICommitMessage(apiKey: string, delimeter?: string) {
+async function generateAICommitMessage(apiKey: string,apiUrl: string, delimeter?: string) {
   try {
     const assertResult = await assertGitRepo();
 
@@ -56,6 +56,7 @@ async function generateAICommitMessage(apiKey: string, delimeter?: string) {
 
         const commitMessage = await generateCommitMessage(
           apiKey,
+          apiUrl,
           staged.diff,
           delimeter
         );
@@ -73,6 +74,7 @@ async function generateAICommitMessage(apiKey: string, delimeter?: string) {
 
     return commitMessage;
   } catch (error: any) {
+    vscode.window.showErrorMessage(error);
     const errorMessage = error?.response?.data?.error?.message;
 
     if (errorMessage) {

--- a/src/autocommit/index.ts
+++ b/src/autocommit/index.ts
@@ -74,7 +74,6 @@ async function generateAICommitMessage(apiKey: string,apiUrl: string, delimeter?
 
     return commitMessage;
   } catch (error: any) {
-    vscode.window.showErrorMessage(error);
     const errorMessage = error?.response?.data?.error?.message;
 
     if (errorMessage) {

--- a/src/autocommit/utils/openai.ts
+++ b/src/autocommit/utils/openai.ts
@@ -11,6 +11,7 @@ import { trimNewLines } from './text';
 
 export const generateCommitMessage = async (
   apiKey: string,
+  apiUrl: string, 
   diff: string,
   delimeter?: string
 ) => {
@@ -19,6 +20,7 @@ export const generateCommitMessage = async (
   const openAI = new OpenAIApi(
     new Configuration({
       apiKey: apiKey,
+      basePath: `${apiUrl}/v1`.replace(/\/+$/, ""),
     })
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,21 @@ async function setOpenAiApiKey(apiKey: string) {
   );
 }
 
+function getOpenAiApiUrl() {
+  const configuration = vscode.workspace.getConfiguration('autocommit');
+  const apiUrl = configuration.get<string>('openAI.apiUrl');
+  return apiUrl;
+}
+
+async function setOpenAiApiUrl(apiUrl: string) {
+  const configuration = vscode.workspace.getConfiguration('autocommit');
+  await configuration.update(
+    'openAI.apiUrl',
+    apiUrl,
+    vscode.ConfigurationTarget.Global
+  );
+}
+
 function getDelimeter() {
   const configuration = vscode.workspace.getConfiguration('autocommit');
   const delimeter = configuration.get<string>('appearance.delimeter');
@@ -70,9 +85,25 @@ async function generateAICommitCommand() {
 
     await setOpenAiApiKey(apiKey);
   }
+  let apiUrl = getOpenAiApiUrl();
+
+  if (!apiUrl || !apiUrl.startsWith('https://')) {
+    apiUrl = await vscode.window.showInputBox({
+      title: 'Please enter your OpenAi Url starting with https://',
+    });
+
+    if (!apiUrl || apiUrl.trim() === '') {
+      vscode.window.showErrorMessage(
+        'You should set OpenAi API Url before extension using!'
+      );
+      return;
+    }
+
+    await setOpenAiApiUrl(apiUrl);
+  }
 
   const delimeter = getDelimeter();
-  const commitMessage = await generateAICommitMessage(apiKey, delimeter);
+  const commitMessage = await generateAICommitMessage(apiKey, apiUrl, delimeter);
 
   if (!commitMessage) {
     return;


### PR DESCRIPTION
1. add autocommit.openAI.apiUrl to the configuration.
2. add runtime check to ensure apiUrl starts with 'https://'.
3. add apiUrl to related function arguments.
